### PR TITLE
Add California Grants Portal Filter

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -176,6 +176,7 @@ export default function Dashboard() {
   const getSourceBadge = (source: string) => {
     const sourceColors: { [key: string]: string } = {
       'grants_gov': 'bg-blue-100 text-blue-800',
+      'california': 'bg-amber-100 text-amber-800',
       'sam_gov': 'bg-purple-100 text-purple-800',
       'state': 'bg-green-100 text-green-800',
       'local': 'bg-orange-100 text-orange-800',
@@ -186,6 +187,7 @@ export default function Dashboard() {
   const getSourceLabel = (source: string) => {
     const labels: { [key: string]: string } = {
       'grants_gov': 'Grants.gov',
+      'california': 'California',
       'sam_gov': 'SAM.gov',
       'state': 'State',
       'local': 'Local',
@@ -282,8 +284,9 @@ export default function Dashboard() {
                 >
                   <option value="all">All Sources</option>
                   <option value="grants_gov">Grants.gov</option>
+                  <option value="california">California Grants Portal</option>
                   <option value="sam_gov">SAM.gov</option>
-                  <option value="state">State</option>
+                  <option value="state">Other State</option>
                   <option value="local">Local</option>
                 </select>
               </div>

--- a/frontend/src/app/opportunities/page.tsx
+++ b/frontend/src/app/opportunities/page.tsx
@@ -233,6 +233,7 @@ export default function OpportunitiesPage() {
   const getSourceBadge = (source: string) => {
     const sourceColors: { [key: string]: string } = {
       'grants_gov': 'bg-blue-100 text-blue-800',
+      'california': 'bg-amber-100 text-amber-800',
       'sam_gov': 'bg-purple-100 text-purple-800',
       'state': 'bg-green-100 text-green-800',
       'local': 'bg-orange-100 text-orange-800',
@@ -243,6 +244,7 @@ export default function OpportunitiesPage() {
   const getSourceLabel = (source: string) => {
     const labels: { [key: string]: string } = {
       'grants_gov': 'Grants.gov',
+      'california': 'California',
       'sam_gov': 'SAM.gov',
       'state': 'State',
       'local': 'Local',
@@ -350,8 +352,9 @@ export default function OpportunitiesPage() {
                 >
                   <option value="all">All Sources</option>
                   <option value="grants_gov">Grants.gov</option>
+                  <option value="california">California Grants Portal</option>
                   <option value="sam_gov">SAM.gov</option>
-                  <option value="state">State</option>
+                  <option value="state">Other State</option>
                   <option value="local">Local</option>
                 </select>
               </div>


### PR DESCRIPTION
## Added California Grants Portal Filter

### Changes:
- Added "California Grants Portal" option to source filter dropdown on Dashboard page
- Added "California Grants Portal" option to source filter dropdown on Opportunities page  
- Added amber badge color for California grants
- Updated source labels to display "California"

### Backend:
- Backend already has California API integration working
- California grants are being scraped and stored with source: "california"

### Testing:
- Tested locally on port 3000
- Filter works correctly on both pages
- California grants display with amber badges