### PR TITLE
Replace description editing with Notes feature

### DIFF
--- a/backend/migrations/add_notes_column.sql
+++ b/backend/migrations/add_notes_column.sql
@@ -1,0 +1,9 @@
+-- Migration: Add notes column to saved_opportunities table
+-- Run this in Supabase SQL Editor
+
+ALTER TABLE saved_opportunities
+ADD COLUMN IF NOT EXISTS notes TEXT DEFAULT '';
+
+-- Add comment
+COMMENT ON COLUMN saved_opportunities.notes IS 'User notes about the opportunity';
+

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -34,6 +34,13 @@ export const api = {
       body: JSON.stringify({ description })
     }),
 
+  updateOpportunityNotes: (opportunityId: string, notes: string) =>
+    fetch(`${API_BASE_URL}/api/opportunities/${opportunityId}/notes`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes })
+    }),
+
   generateOpportunitySummary: (opportunityId: string) =>
     fetch(`${API_BASE_URL}/api/opportunities/${opportunityId}/generate-summary`, {
       method: 'POST',


### PR DESCRIPTION
- Remove description editing functionality from opportunities page
- Add Notes section below Similar Past RFPs with textarea and save functionality
- Add backend PATCH endpoint /api/opportunities/{id}/notes
- Add updateOpportunityNotes API function to frontend
- Add migration file for notes column (to be run in Supabase)
- Change 'View / Edit Description' to 'View Description'