### PR TITLE
fix: remove stray character in dashboard table view

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1295,7 +1295,7 @@ export default function Dashboard() {
                     </div>
                   </div>
                 )}
-c              </div>
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Fix
Removes a stray `c` character that was rendering visibly in the dashboard's table view section (line 1298). This was likely introduced during a previous edit session.

## What changed
- Removed errant `c` character before a closing `</div>` tag in `frontend/src/app/dashboard/page.tsx`

## Testing
- Build passes successfully with `npm run build`
- No visible artifacts in the table view